### PR TITLE
Support periodic-type improper in CHARMM FF

### DIFF
--- a/src/bonded/bonded.cu
+++ b/src/bonded/bonded.cu
@@ -323,11 +323,19 @@ __device__ void function_torsion(ImprPotential ip,real phi,real *fphi,real *lE,b
 {
   real dphi;
 
-  dphi=phi-ip.imp0;
-  dphi-=(2*((real)M_PI))*floor((dphi+((real)M_PI))/(2*((real)M_PI)));
-  fphi[0]=ip.kimp*dphi;
-  if (calcEnergy) {
-    lE[0]=((real)0.5)*ip.kimp*dphi*dphi;
+  if (ip.nimp>0) {
+    dphi=ip.nimp*phi-ip.imp0;
+    fphi[0]=-ip.kimp*ip.nimp*sinf(dphi);
+    if (calcEnergy) {
+      lE[0]=ip.kimp*(cosf(dphi)+1);
+    }
+  } else {
+    dphi=phi-ip.imp0;
+    dphi-=(2*((real)M_PI))*floor((dphi+((real)M_PI))/(2*((real)M_PI)));
+    fphi[0]=((real)2.0)*ip.kimp*dphi;
+    if (calcEnergy) {
+      lE[0]=ip.kimp*dphi*dphi;
+    }
   }
 }
 

--- a/src/system/parameters.cxx
+++ b/src/system/parameters.cxx
@@ -314,8 +314,8 @@ void Parameters::add_parameter_imprs(FILE *fp)
       name.t[1]=check_type_name(io_nexts(line),"IMPROPERS");
       name.t[2]=check_type_name(io_nexts(line),"IMPROPERS");
       name.t[3]=check_type_name(io_nexts(line),"IMPROPERS");
-      ip.kimp=(2.0*KCAL_MOL)*io_nextf(line);
-      io_nexts(line);
+      ip.kimp=KCAL_MOL*io_nextf(line);
+      ip.nimp=io_nexti(line);
       ip.imp0=DEGREES*io_nextf(line);
       imprParameter[name]=ip;
     } else {
@@ -522,7 +522,7 @@ void Parameters::dump()
   for (std::map<TypeName4,struct ImprParameter>::iterator ii=imprParameter.begin(); ii!=imprParameter.end(); ii++) {
     TypeName4 name=ii->first;
     struct ImprParameter ip=ii->second;
-    fprintf(stdout,"%s imprParameter[%6s,%6s,%6s,%6s]={kimp=%g imp0=%g}\n",tag,name.t[0].c_str(),name.t[1].c_str(),name.t[2].c_str(),name.t[3].c_str(),ip.kimp,ip.imp0);
+    fprintf(stdout,"%s imprParameter[%6s,%6s,%6s,%6s]={kimp=%g nimp=%d imp0=%g}\n",tag,name.t[0].c_str(),name.t[1].c_str(),name.t[2].c_str(),name.t[3].c_str(),ip.kimp,ip.nimp,ip.imp0);
   }
   fprintf(stdout,"%s\n",tag);
 
@@ -646,7 +646,7 @@ void blade_add_parameter_dihes(System *system,const char *t1,const char *t2,cons
   system->parameters->maxDiheTerms=((system->parameters->maxDiheTerms<diheTerms)?diheTerms:system->parameters->maxDiheTerms);
 }
 
-void blade_add_parameter_imprs(System *system,const char *t1,const char *t2,const char *t3,const char *t4,double kimp,double imp0)
+void blade_add_parameter_imprs(System *system,const char *t1,const char *t2,const char *t3,const char *t4,double kimp,int nimp,double imp0)
 {
   TypeName4 name;
   struct ImprParameter ip;
@@ -655,7 +655,8 @@ void blade_add_parameter_imprs(System *system,const char *t1,const char *t2,cons
   name.t[1]=t2;
   name.t[2]=t3;
   name.t[3]=t4;
-  ip.kimp=(2.0*KCAL_MOL)*kimp;
+  ip.kimp=KCAL_MOL*kimp;
+  ip.nimp=nimp;
   ip.imp0=DEGREES*imp0;
   system+=omp_get_thread_num();
   system->parameters->imprParameter[name]=ip;

--- a/src/system/parameters.h
+++ b/src/system/parameters.h
@@ -61,6 +61,7 @@ struct DiheParameter {
 
 struct ImprParameter {
   real kimp;
+  int nimp;
   real imp0;
 };
 
@@ -210,7 +211,7 @@ extern "C" {
     double kdih,int ndih,double dih0);
   void blade_add_parameter_imprs(System *system,
     const char *t1,const char *t2,const char *t3,const char *t4,
-    double kimp,double imp0);
+    double kimp,int nimp,double imp0);
   void blade_add_parameter_cmaps(System *system,
     const char *t1,const char *t2,const char *t3,const char *t4,
     const char *t5,const char *t6,const char *t7,const char *t8,

--- a/src/system/potential.cxx
+++ b/src/system/potential.cxx
@@ -657,6 +657,7 @@ void Potential::initialize(System *system)
       }
     }
     impr.kimp=ip.kimp;
+    impr.nimp=ip.nimp;
     impr.imp0=ip.imp0;
     if (rest) impr.kimp*=system->msld->restScaling;
     if (soft) {

--- a/src/system/potential.h
+++ b/src/system/potential.h
@@ -70,6 +70,7 @@ struct ImprPotential {
   int idx[4];
   int siteBlock[2];
   real kimp;
+  int nimp;
   real imp0;
 };
 


### PR DESCRIPTION
Hi, BLaDE developer(s).

While testing lambda-dynamics with ligands parameterized using GAFF, we realized that the periodic-type improper in CHARMM PRM file, which uses a cosine functional form, is not supported.
So, I made a slight change to support it.
It would be great if you consider merging this update into BLaDE.

Please let me know if there is any issue.